### PR TITLE
Added test for match array element

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -151,8 +151,16 @@ export function matcher (originalQuery) {
       return true;
     }
 
+
+
     return _.every(query, (value, key) => {
-      if (value !== null && typeof value === 'object') {
+      if (Array.isArray(item[key])) {
+        if (!Array.isArray(value)) value = [value];
+        
+        return !(value.map((v) => {
+          return item[key].includes(v);
+        }).includes(false));
+      } else if (value !== null && typeof value === 'object') {
         return _.every(value, (target, filterType) => {
           if (specialFilters[filterType]) {
             const filter = specialFilters[filterType](key, target);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -371,23 +371,25 @@ describe('feathers-commons utils', () => {
       expect(matches({ name: 'Marshall', counter: 0 })).to.be.ok;
     });
 
-    it('match an array element', () => {
+    it('matches a string in an array', () => {
       const matchesString = matcher({
-        name: { name: 'Nico' }
+        name: 'Nico'
       });
 
       expect(matchesString({ name: ['Nico', 'Eric'] })).to.be.ok;
       expect(!matchesString({ name: ['Marshall'] })).to.be.ok;
+    });
 
+    it('matches an array of strings (with a single string) in an array', () => {
       const matchesArray = matcher({
-        name: { name: ['Nico'] }
+        name: ['Nico']
       });
 
       expect(matchesArray({ name: ['Nico', 'Eric'] })).to.be.ok;
       expect(!matchesArray({ name: ['Marshall'] })).to.be.ok;
 
       const matchesArrayMultiple = matcher({
-        name: { name: ['Nico', 'Eric'] }
+        name: ['Nico', 'Eric']
       });
 
       expect(matchesArrayMultiple({ name: ['Nico', 'Eric'] })).to.be.ok;
@@ -396,7 +398,7 @@ describe('feathers-commons utils', () => {
       expect(!matchesArrayMultiple({ name: ['Marshall'] })).to.be.ok;
     });
 
-    it('with null values', () => {
+    it('matches an array of multiple strings in an array', () => {
       const matches = matcher({
         counter: null,
         name: { $in: ['Eric', 'Marshall'] }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -371,6 +371,31 @@ describe('feathers-commons utils', () => {
       expect(matches({ name: 'Marshall', counter: 0 })).to.be.ok;
     });
 
+    it('match an array element', () => {
+      const matchesString = matcher({
+        name: { name: 'Nico' }
+      });
+
+      expect(matchesString({ name: ['Nico', 'Eric'] })).to.be.ok;
+      expect(!matchesString({ name: ['Marshall'] })).to.be.ok;
+
+      const matchesArray = matcher({
+        name: { name: ['Nico'] }
+      });
+
+      expect(matchesArray({ name: ['Nico', 'Eric'] })).to.be.ok;
+      expect(!matchesArray({ name: ['Marshall'] })).to.be.ok;
+
+      const matchesArrayMultiple = matcher({
+        name: { name: ['Nico', 'Eric'] }
+      });
+
+      expect(matchesArrayMultiple({ name: ['Nico', 'Eric'] })).to.be.ok;
+      expect(!matchesArrayMultiple({ name: ['Nico'] })).to.be.ok;
+      expect(!matchesArrayMultiple({ name: ['Eric'] })).to.be.ok;
+      expect(!matchesArrayMultiple({ name: ['Marshall'] })).to.be.ok;
+    });
+
     it('with null values', () => {
       const matches = matcher({
         counter: null,


### PR DESCRIPTION
### Summary

It seems that the matcher is not supporting to find a string in an array (as described here: https://docs.mongodb.com/manual/tutorial/query-documents/#match-an-array-element) like in the following example:

**query**: {
studentIds: "123"
}

**Item from MongoDB:**
{
_id: "...",
studentIds: ["123", "456"]
}

In this case the matcher would return false but should return true.

I managed to solve this by adding the following code to matcher (but maybe you guys have a better idea for the implementation): https://github.com/feathersjs/feathers-commons/pull/48/files#diff-2b4ca49d4bb0a774c4d4c1672d7aa781R157
