### PR TITLE
Remove unused utilities and add some inline documentation

### DIFF
--- a/lib/filter-query.js
+++ b/lib/filter-query.js
@@ -1,5 +1,6 @@
 const { _ } = require('./utils');
 
+// Officially supported query parameters ($populate is kind of special)
 const PROPERTIES = ['$sort', '$limit', '$skip', '$select', '$populate'];
 
 function parse (number) {
@@ -8,6 +9,8 @@ function parse (number) {
   }
 }
 
+// Returns the pagination limit and will take into account the
+// default and max pagination settings
 function getLimit (limit, paginate) {
   if (paginate && paginate.default) {
     const lower = typeof limit === 'number' ? limit : paginate.default;
@@ -19,6 +22,7 @@ function getLimit (limit, paginate) {
   return limit;
 }
 
+// Makes sure that $sort order is always converted to an actual number
 function convertSort (sort) {
   if (typeof sort !== 'object') {
     return sort;
@@ -26,11 +30,17 @@ function convertSort (sort) {
 
   const result = {};
 
-  Object.keys(sort).forEach(key => (result[key] = typeof sort[key] === 'object' ? sort[key] : parseInt(sort[key], 10)));
+  Object.keys(sort).forEach(key => {
+    result[key] = typeof sort[key] === 'object'
+      ? sort[key] : parseInt(sort[key], 10);
+  });
 
   return result;
 }
 
+// Converts Feathers special query parameters and pagination settings
+// and returns them separately a `filters` and the rest of the query
+// as `query`
 module.exports = function (query, paginate) {
   let filters = {
     $sort: convertSort(query.$sort),

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -308,6 +308,30 @@ describe('hook utilities', () => {
       });
     });
 
+    it('next and next with error', () => {
+      const dummyHook = {
+        type: 'dummy',
+        method: 'something'
+      };
+
+      const promise = utils.processHooks([
+        function (hook, next) {
+          hook.test = 'first ran';
+
+          next();
+        },
+
+        function (hook, next) {
+          next(new Error('This did not work'));
+        }
+      ], dummyHook);
+
+      return promise.catch(error => {
+        expect(error.message).to.equal('This did not work');
+        expect(error.hook.test).to.equal('first ran');
+      });
+    });
+
     it('errors when invalid hook object is returned', () => {
       const dummyHook = {
         type: 'dummy',

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -7,7 +7,6 @@ describe('module', () => {
     console.log(commons);
     expect(typeof commons).to.equal('object');
     expect(typeof commons.stripSlashes).to.equal('function');
-    expect(typeof commons.matcher).to.equal('function');
     expect(typeof commons.sorter).to.equal('function');
     expect(typeof commons.select).to.equal('function');
     expect(typeof commons.validateArguments).to.equal('function');


### PR DESCRIPTION
Due to using Sift for `feathers-memory` and `feathers-reactive` we won't be needing the utility function for the special query parameters anymore.

Also added some more inline comments to explain what things are doing.