### PR TITLE
skipNextHooks

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -159,14 +159,26 @@ exports.processHooks = function processHooks (hooks, initialHookObject) {
 
     if (hook.length === 2) { // function(hook, next)
       promise = promise.then(hookObject => {
-        return new Promise((resolve, reject) => {
-          hook(hookObject, (error, result) =>
-            error ? reject(error) : resolve(result)
-          );
-        });
+        if (hookObject.__skipNextHooks === true) {
+          // skip hook
+          return Promise.resolve(hookObject);
+        } else {
+          return new Promise((resolve, reject) => {
+            hook(hookObject, (error, result) =>
+              error ? reject(error) : resolve(result)
+            );
+          });
+        }
       });
     } else { // function(hook)
-      promise = promise.then(hook);
+      promise = promise.then(hookObject => {
+        if (hookObject.__skipNextHooks === true) {
+          // skip hook
+          return Promise.resolve(hookObject);
+        } else {
+          return hook(hookObject);
+        }
+      });
     }
 
     // Use the returned hook object or the old one

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -13,7 +13,7 @@ function convertUpdateOrPatch (args) {
 }
 
 // To skip further hooks
-const SKIP = exports.skip = typeof Symbol !== 'undefined' ? Symbol('skip') : '__feathersSkipHooks';
+const SKIP = exports.SKIP = typeof Symbol !== 'undefined' ? Symbol('skip') : '__feathersSkipHooks';
 
 // Converters from service method arguments to hook object properties
 exports.converters = {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -13,7 +13,7 @@ function convertUpdateOrPatch (args) {
 }
 
 // To skip further hooks
-exports.skip = Symbol('skip');
+const SKIP = exports.skip = typeof Symbol !== 'undefined' ? Symbol('skip') : '__feathersSkipHooks';
 
 // Converters from service method arguments to hook object properties
 exports.converters = {
@@ -144,8 +144,8 @@ exports.processHooks = function processHooks (hooks, initialHookObject) {
     // Either use the returned hook object or the current
     // hook object from the chain if the hook returned undefined
     if (current) {
-      if (current === exports.skip) {
-        return exports.skip;
+      if (current === SKIP) {
+        return SKIP;
       }
 
       if (!exports.isHookObject(current)) {
@@ -165,27 +165,13 @@ exports.processHooks = function processHooks (hooks, initialHookObject) {
     const hook = fn.bind(this);
 
     if (hook.length === 2) { // function(hook, next)
-      promise = promise.then(hookObject => {
-        if (hookObject === exports.skip) {
-          // skip hook
-          return Promise.resolve(exports.skip);
-        } else {
-          return new Promise((resolve, reject) => {
-            hook(hookObject, (error, result) =>
-              error ? reject(error) : resolve(result)
-            );
-          });
-        }
-      });
+      promise = promise.then(hookObject => hookObject === SKIP ? SKIP : new Promise((resolve, reject) => {
+        hook(hookObject, (error, result) =>
+          error ? reject(error) : resolve(result)
+        );
+      }));
     } else { // function(hook)
-      promise = promise.then(hookObject => {
-        if (hookObject === exports.skip) {
-          // skip hook
-          return Promise.resolve(exports.skip);
-        } else {
-          return hook(hookObject);
-        }
-      });
+      promise = promise.then(hookObject => hookObject === SKIP ? SKIP : hook(hookObject));
     }
 
     // Use the returned hook object or the old one

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -12,6 +12,9 @@ function convertUpdateOrPatch (args) {
   return { id, data, params };
 }
 
+// To skip further hooks
+exports.skip = Symbol('skip');
+
 // Converters from service method arguments to hook object properties
 exports.converters = {
   find (args) {
@@ -141,6 +144,10 @@ exports.processHooks = function processHooks (hooks, initialHookObject) {
     // Either use the returned hook object or the current
     // hook object from the chain if the hook returned undefined
     if (current) {
+      if (current === exports.skip) {
+        return hookObject;
+      }
+
       if (!exports.isHookObject(current)) {
         throw new Error(`${hookObject.type} hook for '${hookObject.method}' method returned invalid hook object`);
       }
@@ -159,9 +166,9 @@ exports.processHooks = function processHooks (hooks, initialHookObject) {
 
     if (hook.length === 2) { // function(hook, next)
       promise = promise.then(hookObject => {
-        if (hookObject.__skipNextHooks === true) {
+        if (hookObject === exports.skip) {
           // skip hook
-          return Promise.resolve(hookObject);
+          return Promise.resolve(exports.skip);
         } else {
           return new Promise((resolve, reject) => {
             hook(hookObject, (error, result) =>
@@ -172,9 +179,9 @@ exports.processHooks = function processHooks (hooks, initialHookObject) {
       });
     } else { // function(hook)
       promise = promise.then(hookObject => {
-        if (hookObject.__skipNextHooks === true) {
+        if (hookObject === exports.skip) {
           // skip hook
-          return Promise.resolve(hookObject);
+          return Promise.resolve(exports.skip);
         } else {
           return hook(hookObject);
         }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -145,7 +145,7 @@ exports.processHooks = function processHooks (hooks, initialHookObject) {
     // hook object from the chain if the hook returned undefined
     if (current) {
       if (current === exports.skip) {
-        return hookObject;
+        return exports.skip;
       }
 
       if (!exports.isHookObject(current)) {
@@ -192,11 +192,13 @@ exports.processHooks = function processHooks (hooks, initialHookObject) {
     promise = promise.then(updateCurrentHook);
   });
 
-  return promise.catch(error => {
-    // Add the hook information to any errors
-    error.hook = hookObject;
-    throw error;
-  });
+  return promise
+    .then(() => hookObject)
+    .catch(error => {
+      // Add the hook information to any errors
+      error.hook = hookObject;
+      throw error;
+    });
 };
 
 // Add `.hooks` functionality to an object

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -102,11 +102,11 @@ describe('hook utilities', () => {
         other: 'value',
         hi: [ 'foo', 'bar' ]
       }))
-      .to.deep.equal({
-        all: [ 'thing' ],
-        other: [ 'value' ],
-        hi: [ 'foo', 'bar' ]
-      });
+        .to.deep.equal({
+          all: [ 'thing' ],
+          other: [ 'value' ],
+          hi: [ 'foo', 'bar' ]
+        });
     });
   });
 
@@ -322,6 +322,47 @@ describe('hook utilities', () => {
           type: 'dummy',
           method: 'something',
           chain: [ 'first', 'second', 'third', 'fourth' ]
+        });
+      });
+    });
+
+    it('skip next hooks', () => {
+      const dummyHook = {
+        type: 'dummy',
+        method: 'something'
+      };
+
+      const promise = utils.processHooks([
+        function (hook) {
+          hook.chain = [ 'first' ];
+
+          return Promise.resolve(hook);
+        },
+
+        function (hook, next) {
+          hook.chain.push('second');
+
+          next();
+        },
+
+        hook => {
+          hook.__skipNextHooks = true;
+          hook.chain.push('third');
+        },
+
+        function (hook) {
+          hook.chain.push('fourth');
+
+          return hook;
+        }
+      ], dummyHook);
+
+      return promise.then(result => {
+        expect(result).to.deep.equal({
+          __skipNextHooks: true,
+          type: 'dummy',
+          method: 'something',
+          chain: [ 'first', 'second', 'third' ]
         });
       });
     });

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -348,7 +348,7 @@ describe('hook utilities', () => {
         hook => {
           hook.chain.push('third');
 
-          return utils.skip;
+          return utils.SKIP;
         },
 
         function (hook) {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -326,7 +326,7 @@ describe('hook utilities', () => {
       });
     });
 
-    it('skip next hooks', () => {
+    it('skip further hooks', () => {
       const dummyHook = {
         type: 'dummy',
         method: 'something'
@@ -346,8 +346,9 @@ describe('hook utilities', () => {
         },
 
         hook => {
-          hook.__skipNextHooks = true;
           hook.chain.push('third');
+
+          return utils.skip;
         },
 
         function (hook) {
@@ -359,7 +360,6 @@ describe('hook utilities', () => {
 
       return promise.then(result => {
         expect(result).to.deep.equal({
-          __skipNextHooks: true,
           type: 'dummy',
           method: 'something',
           chain: [ 'first', 'second', 'third' ]


### PR DESCRIPTION
When setting `context.result` on a before hook, the original service is skipped, but all other before hooks, and after hooks are executed.

Sometimes, one just wants the result to be sent immediatly in a before hook, without executing the all Promises (hooks) chain.

This PR is a proposal to tell a hook to "immediatly" send the respose, bypass all further hooks. By setting `context.__skipNextHooks`, all further hooks (before & after) will be skipped, resulting the `context.result` to be sent as-is.
